### PR TITLE
added 3 new loadouts

### DIFF
--- a/Premade loadouts/IDF_70s_FAL.sqf
+++ b/Premade loadouts/IDF_70s_FAL.sqf
@@ -481,7 +481,7 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 4 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
 
-      this addBackpack "rhs_M252_Gun_Bag";
+      this addBackpack "I_Mortar_01_weapon_F";
 
       this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
 
@@ -508,7 +508,7 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 4 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
 
-      this addBackpack "rhs_M252_Bipod_Bag";
+      this addBackpack "I_Mortar_01_support_F";
 
       this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
 

--- a/Premade loadouts/IDF_70s_FAL.sqf
+++ b/Premade loadouts/IDF_70s_FAL.sqf
@@ -18,7 +18,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: COMMANDER
     case "co": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -48,7 +47,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: DEPUTY COMMANDER AND SQUAD LEADER
     case "dc": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -78,7 +76,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: FUCKING AIR COMMANDER
     case "fac": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -110,7 +107,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: MEDIC
     case "m": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_tourniquet";
       this addItemToUniform "ACE_EntrenchingTool";
       this addItemToUniform "ACE_CableTie";
@@ -142,7 +138,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: FIRE TEAM LEADER
     case "ftl": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -172,7 +167,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: RIFLEMAN
     case "r": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -199,7 +193,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: AUTOMATIC RIFLEMAN
     case "ar": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -227,7 +220,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: ASSISTANT AUTOMATIC RIFLEMAN
     case "aar": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -255,7 +247,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: RIFLEMAN (AT)
     case "rat": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -283,7 +274,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: MEDIUM MG TEAM LEADER
     case "mmgtl": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -313,7 +303,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: MEDIUM MG GUNNER
     case "mmgg": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACRE_PRC343_ID_1";
@@ -342,7 +331,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: MEDIUM MG AMMO BEARER
     case "mmgab": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -370,7 +358,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: MEDIUM AT TEAM LEADER
     case "mattl": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -400,7 +387,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: MEDIUM AT MISSILE SPECIALIST
     case "matg": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -427,7 +413,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: MEDIUM AT ASSISTANT MISSILE SPECIALIST
     case "matab": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -455,7 +440,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: MORTAR TEAM LEADER
     case "mtrl": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -486,7 +470,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: MORTAR GUNNER
     case "mtrg": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -512,12 +495,13 @@ switch (_typeOfUnit) do {
 // LOADOUT: MORTAR ASSISTANT
     case "mtra": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
       this addItemToUniform "ACE_EntrenchingTool";
       this addItemToUniform "ACE_CableTie";
+      this addItemToUniform "ACE_MapTools";
+      this addItemToUniform "ACE_RangeTable_82mm";
 
       this addVest "MNP_Vest_Light_R3";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
@@ -538,7 +522,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: PILOT
     case "p": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -563,7 +546,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: CO-PILOT
     case "cp": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -588,7 +570,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: VEHICLE COMMANDER
     case "vc": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -612,7 +593,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: VEHICLE DRIVER
     case "vd": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
@@ -634,7 +614,6 @@ switch (_typeOfUnit) do {
 // LOADOUT: VEHICLE GUNNER
     case "vg": {
       this forceAddUniform "MNP_CombatUniform_ISR";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_morphine";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";

--- a/Premade loadouts/IDF_70s_FAL.sqf
+++ b/Premade loadouts/IDF_70s_FAL.sqf
@@ -1,0 +1,663 @@
+// LOADOUT BY MATUZALEM
+//
+// IDF loadout from around 70s, think Yom Kippur war. For when you want to absolutely destroy kebab.
+//
+// history:
+//     21-Dec-2016: initial version
+
+removeAllWeapons this;
+removeAllItems this;
+removeAllAssignedItems this;
+removeUniform this;
+removeVest this;
+removeBackpack this;
+removeHeadgear this;
+removeGoggles this;
+
+switch (_typeOfUnit) do {
+// LOADOUT: COMMANDER
+    case "co": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 2 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_SL_A";
+      for "_i" from 1 to 8 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+   };
+
+// LOADOUT: DEPUTY COMMANDER AND SQUAD LEADER
+    case "dc": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 2 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_SL_A";
+      for "_i" from 1 to 8 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: FUCKING AIR COMMANDER
+    case "fac": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 2 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_mag_an_m8hc";};
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_m18_red";};
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_m18_green";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_MTP_JTAC_H_A";
+      for "_i" from 1 to 8 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIC
+    case "m": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      for "_i" from 1 to 9 do {this addItemToUniform "SmokeShell";};
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_mag_an_m8hc";};
+      for "_i" from 1 to 3 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_MTP_Medic_H_B";
+      for "_i" from 1 to 40 do {this addItemToBackpack "ACE_fieldDressing";};
+      for "_i" from 1 to 20 do {this addItemToBackpack "ACE_morphine";};
+      for "_i" from 1 to 10 do {this addItemToBackpack "ACE_personalAidKit";};
+      for "_i" from 1 to 5 do {this addItemToBackpack "ACE_salineIV_250";};
+      for "_i" from 1 to 5 do {this addItemToBackpack "ACE_salineIV_500";};
+      for "_i" from 1 to 15 do {this addItemToBackpack "ACE_epinephrine";};
+      for "_i" from 1 to 3 do {this addItemToBackpack "hlc_20Rnd_762x51_T_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: FIRE TEAM LEADER
+    case "ftl": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 2 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_SL_A";
+      for "_i" from 1 to 8 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: RIFLEMAN
+    case "r": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 4 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_Rifleman_A";
+      for "_i" from 1 to 6 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: AUTOMATIC RIFLEMAN
+    case "ar": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      this addItemToVest "hlc_50rnd_762x51_M_FAL";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_Rifleman_B";
+      for "_i" from 1 to 6 do {this addItemToBackpack "hlc_50rnd_762x51_M_FAL";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      // uses the same FAL as everybody else, unfortunately no version with bipod was available
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: ASSISTANT AUTOMATIC RIFLEMAN
+    case "aar": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 4 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_Rifleman_B";
+      for "_i" from 1 to 4 do {this addItemToBackpack "hlc_50rnd_762x51_M_FAL";};
+      for "_i" from 1 to 4 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: RIFLEMAN (AT)
+    case "rat": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 4 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_Rifleman_A";
+      for "_i" from 1 to 6 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+      this addWeapon "rhs_weap_m72a7";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM MG TEAM LEADER
+    case "mmgtl": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 2 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_SL_A";
+      for "_i" from 1 to 8 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM MG GUNNER
+    case "mmgg": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACRE_PRC343_ID_1";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 4 do {this addItemToVest "rhsusf_mag_7x45acp_MHP";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_Rifleman_A";
+      for "_i" from 1 to 2 do {this addItemToBackpack "UK3CB_BAF_762_100Rnd";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "UK3CB_BAF_L7A2";
+      this addWeapon "rhsusf_weap_m1911a1";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM MG AMMO BEARER
+    case "mmgab": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 4 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_Rifleman_B";
+      for "_i" from 1 to 3 do {this addItemToBackpack "UK3CB_BAF_762_100Rnd";};
+      for "_i" from 1 to 5 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM AT TEAM LEADER
+    case "mattl": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 2 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_SL_A";
+      for "_i" from 1 to 8 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM AT MISSILE SPECIALIST
+    case "matg": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 4 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_Rifleman_A";
+      for "_i" from 1 to 4 do {this addItemToBackpack "rhs_rpg7_PG7VL_mag";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM AT ASSISTANT MISSILE SPECIALIST
+    case "matab": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 3 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_Rifleman_A";
+      for "_i" from 1 to 6 do {this addItemToBackpack "rhs_rpg7_PG7VL_mag";};
+      for "_i" from 1 to 6 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MORTAR TEAM LEADER
+    case "mtrl": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+      this addItemToUniform "ACE_MapTools";
+      this addItemToUniform "ACE_RangeTable_82mm";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 2 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 5 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "UK3CB_BAF_B_Bergen_OLI_SL_A";
+      for "_i" from 1 to 8 do {this addItemToBackpack "hlc_20Rnd_762x51_B_fal";};
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MORTAR GUNNER
+    case "mtrg": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 4 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "rhs_M252_Gun_Bag";
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MORTAR ASSISTANT
+    case "mtra": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "MNP_Vest_Light_R3";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_m67";};
+      for "_i" from 1 to 4 do {this addItemToVest "hlc_20Rnd_762x51_B_fal";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_an_m8hc";};
+
+      this addBackpack "rhs_M252_Bipod_Bag";
+
+      this addHeadgear "UK3CB_BAF_H_Mk7_Scrim_E";
+
+      this addWeapon "hlc_rifle_FAL5000";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: PILOT
+    case "p": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+      for "_i" from 1 to 3 do {this addItemToUniform "rhsusf_mag_7x45acp_MHP";};
+
+      this addVest "rhs_6sh46";
+      for "_i" from 1 to 3 do {this addItemToVest "rhsusf_mag_7x45acp_MHP";};
+
+      this addHeadgear "rhs_zsh7a_mike_green";
+
+      this addGoggles "G_Aviator";
+
+      this addWeapon "rhsusf_weap_m1911a1";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: CO-PILOT
+    case "cp": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+      for "_i" from 1 to 3 do {this addItemToUniform "rhsusf_mag_7x45acp_MHP";};
+
+      this addVest "rhs_6sh46";
+      for "_i" from 1 to 3 do {this addItemToVest "rhsusf_mag_7x45acp_MHP";};
+
+      this addHeadgear "rhs_zsh7a_mike_green";
+
+      this addGoggles "G_Aviator";
+
+      this addWeapon "rhsusf_weap_m1911a1";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: VEHICLE COMMANDER
+    case "vc": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "rhs_6sh46";
+      for "_i" from 1 to 5 do {this addItemToVest "rhsusf_mag_7x45acp_MHP";};
+
+      this addHeadgear "rhsusf_cvc_green_helmet";
+
+      this addWeapon "rhsusf_weap_m1911a1";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: VEHICLE DRIVER
+    case "vd": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "rhs_6sh46";
+      for "_i" from 1 to 5 do {this addItemToVest "rhsusf_mag_7x45acp_MHP";};
+
+      this addHeadgear "rhsusf_cvc_green_helmet";
+
+      this addWeapon "rhsusf_weap_m1911a1";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: VEHICLE GUNNER
+    case "vg": {
+      this forceAddUniform "MNP_CombatUniform_ISR";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_morphine";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EntrenchingTool";
+      this addItemToUniform "ACE_CableTie";
+
+      this addVest "rhs_6sh46";
+      for "_i" from 1 to 5 do {this addItemToVest "rhsusf_mag_7x45acp_MHP";};
+
+      this addHeadgear "rhsusf_cvc_green_helmet";
+
+      this addWeapon "rhsusf_weap_m1911a1";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: DEFAULT/UNDEFINED (use RIFLEMAN)
+    default {
+        if (_typeOfUnit != "r") then {["r", this] call f_fnc_assignGear;};
+        if (true) exitWith {player globalChat format ["DEBUG (f\assignGear\f_assignGear_blufor.sqf): Unit = %1. Gear template %2 does not exist, used Rifleman instead.", this, _typeOfUnit]};
+    };
+};
+
+this selectWeapon primaryWeapon this;

--- a/Premade loadouts/RUS_CW_D_ak74m.sqf
+++ b/Premade loadouts/RUS_CW_D_ak74m.sqf
@@ -1,0 +1,594 @@
+// LOADOUT BY MATUZALEM
+//
+// Cold war, specifically late 70s to early 90s, loadout for Soviet/Russian desert line infantry. Great for BTFO-by-poorly-trained-militias reenactment.
+//
+// history:
+//     21-Dec-2016: initial version
+
+removeAllWeapons this;
+removeAllItems this;
+removeAllAssignedItems this;
+removeUniform this;
+removeVest this;
+removeBackpack this;
+removeHeadgear this;
+removeGoggles this;
+
+switch (_typeOfUnit) do {
+// LOADOUT: COMMANDER
+    case "co": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_VG40OP_white";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+   };
+
+// LOADOUT: DEPUTY COMMANDER AND SQUAD LEADER
+    case "dc": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_VG40OP_white";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: FUCKING AIR COMMANDER
+    case "fac": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VG40OP_red";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_VG40OP_green";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIC
+    case "m": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_medic";
+      for "_i" from 1 to 5 do {this addItemToVest "ACE_salineIV_250";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_f1";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addBackpack "rhs_assault_umbts";
+      for "_i" from 1 to 50 do {this addItemToBackpack "ACE_fieldDressing";};
+      for "_i" from 1 to 20 do {this addItemToBackpack "ACE_morphine";};
+      for "_i" from 1 to 15 do {this addItemToBackpack "ACE_epinephrine";};
+      for "_i" from 1 to 5 do {this addItemToBackpack "ACE_salineIV_500";};
+      for "_i" from 1 to 5 do {this addItemToBackpack "ACE_personalAidKit";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: FIRE TEAM LEADER
+    case "ftl": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_VG40OP_white";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: RIFLEMAN
+    case "r": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_f1";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: AUTOMATIC RIFLEMAN
+    case "ar": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_f1";};
+
+      this addBackpack "rhs_sidor";
+      for "_i" from 1 to 3 do {this addItemToBackpack "rhs_100Rnd_762x54mmR";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_pkm";            // because RHS didn't release the RPK series, this makes MMG teams sort of useless
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: ASSISTANT AUTOMATIC RIFLEMAN
+    case "aar": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_f1";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addBackpack "rhs_sidor";
+      for "_i" from 1 to 3 do {this addItemToBackpack "rhs_100Rnd_762x54mmR";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: RIFLEMAN (AT)
+    case "rat": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_f1";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addBackpack "rhs_rpg_empty";
+      this addItemToBackpack "rhs_rpg7_PG7VL_mag";
+
+      for "_i" from 1 to 2 do {this addItemToBackpack "rhs_rpg7_OG7V_mag";};
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+      this addWeapon "rhs_weap_rpg7";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM MG TEAM LEADER
+    case "mmgtl": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_VG40OP_white";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+
+    };
+
+// LOADOUT: MEDIUM MG GUNNER
+    case "mmgg": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "rhs_sidor";
+      for "_i" from 1 to 2 do {this addItemToBackpack "rhs_100Rnd_762x54mmR";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_pkp";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM MG AMMO BEARER
+    case "mmgab": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "rhs_sidor";
+      for "_i" from 1 to 3 do {this addItemToBackpack "rhs_100Rnd_762x54mmR";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM AT TEAM LEADER
+    case "mattl": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_VG40OP_white";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+
+    };
+
+// LOADOUT: MEDIUM AT MISSILE SPECIALIST
+    case "matg": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "rhs_rpg_empty";
+      for "_i" from 1 to 4 do {this addItemToBackpack "rhs_rpg7_PG7VL_mag";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "rhs_weap_rpg7";
+      this addSecondaryWeaponItem "rhs_acc_pgo7v";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM AT ASSISTANT MISSILE SPECIALIST
+    case "matab": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "rhs_rpg_empty";
+      for "_i" from 1 to 4 do {this addItemToBackpack "rhs_rpg7_PG7VL_mag";};
+      
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+
+    };
+
+// LOADOUT: MORTAR TEAM LEADER
+    case "mtrl": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+      this addItemToUniform "ACE_RangeTable_82mm";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";             
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_VG40OP_white";};
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+
+    };
+
+// LOADOUT: MORTAR GUNNER
+    case "mtrg": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "RHS_Podnos_Gun_Bag";
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MORTAR ASSISTANT
+    case "mtra": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki_rifleman";
+      for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "RHS_Podnos_Bipod_Bag";
+
+      this addHeadgear "rhs_ssh68";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: PILOT
+    case "p": {
+      this forceAddUniform "rhs_uniform_df15_tan";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+
+      this addVest "rhs_vest_pistol_holster";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_9x18_8_57N181S";};
+
+      this addHeadgear "rhs_zsh7a_mike_green_alt";
+
+      this addWeapon "rhs_weap_makarov_pm";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: CO-PILOT
+    case "cp": {
+      this forceAddUniform "rhs_uniform_df15_tan";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+
+      this addVest "rhs_vest_pistol_holster";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_9x18_8_57N181S";};
+
+      this addHeadgear "rhs_zsh7a_mike_green_alt";
+
+      this addWeapon "rhs_weap_makarov_pm";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+
+    };
+
+// LOADOUT: VEHICLE COMMANDER
+    case "vc": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki";
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_tsh4_ess_bala";
+
+      this addWeapon "rhs_weap_aks74u";
+      this addPrimaryWeaponItem "rhs_acc_pgs64_74u";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: VEHICLE DRIVER
+    case "vd": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki";
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_tsh4_ess_bala";
+
+      this addWeapon "rhs_weap_aks74u";
+      this addPrimaryWeaponItem "rhs_acc_pgs64_74u";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: VEHICLE GUNNER
+    case "vg": {
+      this forceAddUniform "rhs_uniform_m88_patchless";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhsgref_6b23_khaki";
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+
+      this addHeadgear "rhs_tsh4_ess_bala";
+
+      this addWeapon "rhs_weap_aks74u";
+      this addPrimaryWeaponItem "rhs_acc_pgs64_74u";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: DEFAULT/UNDEFINED (use RIFLEMAN)
+    default {
+        if (_typeOfUnit != "r") then {["r", this] call f_fnc_assignGear;};
+        if (true) exitWith {player globalChat format ["DEBUG (f\assignGear\f_assignGear_blufor.sqf): Unit = %1. Gear template %2 does not exist, used Rifleman instead.", this, _typeOfUnit]};
+    };
+};
+
+this selectWeapon primaryWeapon this;

--- a/Premade loadouts/RUS_CW_D_ak74m.sqf
+++ b/Premade loadouts/RUS_CW_D_ak74m.sqf
@@ -21,7 +21,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
@@ -47,7 +46,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
@@ -73,7 +71,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
@@ -99,7 +96,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_tourniquet";
       this addItemToUniform "ACE_morphine";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki_medic";
       for "_i" from 1 to 5 do {this addItemToVest "ACE_salineIV_250";};
@@ -130,7 +126,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
@@ -156,7 +151,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_f1";};
@@ -178,7 +172,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_f1";};
@@ -201,7 +194,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_f1";};
@@ -226,7 +218,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_f1";};
@@ -253,7 +244,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
@@ -280,7 +270,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
@@ -304,7 +293,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
       for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -330,7 +318,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
@@ -357,7 +344,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
       for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -386,7 +372,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
       for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -413,7 +398,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
       this addItemToUniform "ACE_RangeTable_82mm";
 
@@ -441,7 +425,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
       for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -466,7 +449,8 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+      this addItemToUniform "ACE_RangeTable_82mm";
 
       this addVest "rhsgref_6b23_khaki_rifleman";
       for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -527,7 +511,6 @@ switch (_typeOfUnit) do {
       this forceAddUniform "rhs_uniform_m88_patchless";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki";
       for "_i" from 1 to 3 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -549,7 +532,6 @@ switch (_typeOfUnit) do {
       this forceAddUniform "rhs_uniform_m88_patchless";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki";
       for "_i" from 1 to 3 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -569,7 +551,6 @@ switch (_typeOfUnit) do {
       this forceAddUniform "rhs_uniform_m88_patchless";
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhsgref_6b23_khaki";
       for "_i" from 1 to 3 do {this addItemToVest "rhs_30Rnd_545x39_AK";};

--- a/Premade loadouts/RUS_CW_D_ak74m.sqf
+++ b/Premade loadouts/RUS_CW_D_ak74m.sqf
@@ -431,7 +431,7 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
 
-      this addBackpack "RHS_Podnos_Gun_Bag";
+      this addBackpack "O_Mortar_01_weapon_F";
 
       this addHeadgear "rhs_ssh68";
 
@@ -457,7 +457,7 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
 
-      this addBackpack "RHS_Podnos_Bipod_Bag";
+      this addBackpack "O_Mortar_01_support_F";
 
       this addHeadgear "rhs_ssh68";
 

--- a/Premade loadouts/RUS_GORKA_ak74m.sqf
+++ b/Premade loadouts/RUS_GORKA_ak74m.sqf
@@ -22,7 +22,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhs_6b23_6sh116_vog";
@@ -50,7 +49,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhs_6b23_6sh116_vog";
@@ -78,7 +76,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhs_6b23_6sh116_vog";
@@ -135,7 +132,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhs_6b23_6sh116_vog";
@@ -163,7 +159,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_6sh116";
       for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -186,7 +181,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_6sh116";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
@@ -208,7 +202,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_6sh116";
       for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -234,7 +227,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_6sh116";
       for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -258,7 +250,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhs_6b23_6sh116_vog";
@@ -289,7 +280,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_6sh116";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
@@ -313,7 +303,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_6sh116";
       for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -340,7 +329,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
 
       this addVest "rhs_6b23_6sh116_vog";
@@ -368,7 +356,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_6sh116";
       for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -396,7 +383,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_6sh116";
       for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -422,7 +408,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
       this addItemToUniform "ACE_MapTools";
       this addItemToUniform "ACE_RangeTable_82mm";
 
@@ -451,7 +436,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_6sh116";
       for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -476,7 +460,8 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+      this addItemToUniform "ACE_RangeTable_82mm";
 
       this addVest "rhs_6b23_6sh116";
       for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
@@ -501,7 +486,7 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
+
       this addVest "rhs_6sh46";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_9x19_17";};
@@ -521,7 +506,7 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
+
       this addVest "rhs_6sh46";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_9x19_17";};
@@ -542,7 +527,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_digi_crew";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
@@ -567,7 +551,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_digi_crew";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
@@ -590,7 +573,6 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
       this addItemToUniform "ACE_morphine";
       this addItemToUniform "ACE_tourniquet";
-      this addItemToUniform "ACE_EarPlugs";
 
       this addVest "rhs_6b23_digi_crew";
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};

--- a/Premade loadouts/RUS_GORKA_ak74m.sqf
+++ b/Premade loadouts/RUS_GORKA_ak74m.sqf
@@ -442,7 +442,7 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
 
-      this addBackpack "RHS_Podnos_Gun_Bag";
+      this addBackpack "I_Mortar_01_weapon_F";
 
       this addHeadgear "rhs_6b7_1m_emr_ess_bala";
 
@@ -468,7 +468,7 @@ switch (_typeOfUnit) do {
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
       for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
 
-      this addBackpack "RHS_Podnos_Bipod_Bag";
+      this addBackpack "I_Mortar_01_support_F";
 
       this addHeadgear "rhs_6b7_1m_emr_ess_bala";
 

--- a/Premade loadouts/RUS_GORKA_ak74m.sqf
+++ b/Premade loadouts/RUS_GORKA_ak74m.sqf
@@ -1,0 +1,617 @@
+// LOADOUT BY MATUZALEM
+//
+// Loadout of modern Russian infantry wearing Gorka suits, great for all you winter months, alpine regions and 
+// definitely-not-supported-by-russia-separatism needs.
+//
+// history:
+//     21-Dec-2016: initial version
+
+removeAllWeapons this;
+removeAllItems this;
+removeAllAssignedItems this;
+removeUniform this;
+removeVest this;
+removeBackpack this;
+removeHeadgear this;
+removeGoggles this;
+
+switch (_typeOfUnit) do {
+// LOADOUT: COMMANDER
+    case "co": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhs_6b23_6sh116_vog";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VG40OP_white";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+            
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+   };
+
+// LOADOUT: DEPUTY COMMANDER AND SQUAD LEADER
+    case "dc": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhs_6b23_6sh116_vog";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VG40OP_white";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+            
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: FUCKING AIR COMMANDER
+    case "fac": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhs_6b23_6sh116_vog";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VG40OP_white";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+            
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIC
+    case "m": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_morphine";
+
+      this addVest "rhs_6b23_6sh116_od";
+      for "_i" from 1 to 5 do {this addItemToVest "ACE_salineIV_250";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 9 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+
+      this addBackpack "rhs_assault_umbts";
+      for "_i" from 1 to 50 do {this addItemToBackpack "ACE_fieldDressing";};
+      for "_i" from 1 to 20 do {this addItemToBackpack "ACE_morphine";};
+      for "_i" from 1 to 15 do {this addItemToBackpack "ACE_epinephrine";};
+      for "_i" from 1 to 5 do {this addItemToBackpack "ACE_salineIV_500";};
+      for "_i" from 1 to 5 do {this addItemToBackpack "ACE_personalAidKit";};
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: FIRE TEAM LEADER
+    case "ftl": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhs_6b23_6sh116_vog";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VG40OP_white";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+            
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: RIFLEMAN
+    case "r": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_6sh116";
+      for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: AUTOMATIC RIFLEMAN
+    case "ar": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_6sh116";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_100Rnd_762x54mmR";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_pkm";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: ASSISTANT AUTOMATIC RIFLEMAN
+    case "aar": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_6sh116";
+      for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "rhs_assault_umbts";
+      for "_i" from 1 to 3 do {this addItemToBackpack "rhs_100Rnd_762x54mmR";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: RIFLEMAN (AT)
+    case "rat": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_6sh116";
+      for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+      this addWeapon "rhs_weap_rpg26";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM MG TEAM LEADER
+    case "mmgtl": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhs_6b23_6sh116_vog";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_VG40OP_white";};
+
+      this addBackpack "rhs_assault_umbts";
+      for "_i" from 1 to 3 do {this addItemToBackpack "rhs_100Rnd_762x54mmR";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM MG GUNNER
+    case "mmgg": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_6sh116";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "rhs_assault_umbts";
+      for "_i" from 1 to 2 do {this addItemToBackpack "rhs_100Rnd_762x54mmR";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_pkp";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM MG AMMO BEARER
+    case "mmgab": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_6sh116";
+      for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      this addItemToVest "rhs_100Rnd_762x54mmR";
+
+      this addBackpack "rhs_assault_umbts";
+      for "_i" from 1 to 3 do {this addItemToBackpack "rhs_100Rnd_762x54mmR";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM AT TEAM LEADER
+    case "mattl": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+
+      this addVest "rhs_6b23_6sh116_vog";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VG40OP_white";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+            
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM AT MISSILE SPECIALIST
+    case "matg": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_6sh116";
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "rhs_rpg_empty";
+      for "_i" from 1 to 4 do {this addItemToBackpack "rhs_rpg7_PG7VL_mag";};
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "rhs_weap_rpg7";
+      this addSecondaryWeaponItem "rhs_acc_pgo7v";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MEDIUM AT ASSISTANT MISSILE SPECIALIST
+    case "matab": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_6sh116";
+      for "_i" from 1 to 8 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "rhs_rpg_empty";
+      for "_i" from 1 to 4 do {this addItemToBackpack "rhs_rpg7_PG7VL_mag";};
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+
+    };
+
+// LOADOUT: MORTAR TEAM LEADER
+    case "mtrl": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addItemToUniform "ACE_MapTools";
+      this addItemToUniform "ACE_RangeTable_82mm";
+
+      this addVest "rhs_6b23_6sh116_vog";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 10 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VOG25";};
+      for "_i" from 1 to 4 do {this addItemToVest "rhs_VG40OP_white";};
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m_gp25";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+            
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MORTAR GUNNER
+    case "mtrg": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_6sh116";
+      for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "RHS_Podnos_Gun_Bag";
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: MORTAR ASSISTANT
+    case "mtra": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_6sh116";
+      for "_i" from 1 to 6 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+
+      this addBackpack "RHS_Podnos_Bipod_Bag";
+
+      this addHeadgear "rhs_6b7_1m_emr_ess_bala";
+
+      this addWeapon "rhs_weap_ak74m";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: PILOT
+    case "p": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addVest "rhs_6sh46";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_9x19_17";};
+      this addHeadgear "rhs_zsh7a_mike_green_alt";
+
+      this addWeapon "rhs_weap_pya";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+      this linkItem "ItemGPS";
+    };
+
+// LOADOUT: CO-PILOT
+    case "cp": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+      this addVest "rhs_6sh46";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_9x19_17";};
+      this addHeadgear "rhs_zsh7a_mike_green_alt";
+
+      this addWeapon "rhs_weap_pya";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+      this linkItem "ItemGPS";
+
+    };
+
+// LOADOUT: VEHICLE COMMANDER
+    case "vc": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_digi_crew";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+
+      this addHeadgear "rhs_tsh4_ess_bala";
+
+      this addWeapon "rhs_weap_aks74u";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this addWeapon "Binocular";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: VEHICLE DRIVER
+    case "vd": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_digi_crew";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+
+      this addHeadgear "rhs_tsh4_ess_bala";
+
+      this addWeapon "rhs_weap_aks74u";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: VEHICLE GUNNER
+    case "vg": {
+      this forceAddUniform "rhs_uniform_gorka_r_g";
+      for "_i" from 1 to 2 do {this addItemToUniform "ACE_fieldDressing";};
+      this addItemToUniform "ACE_morphine";
+      this addItemToUniform "ACE_tourniquet";
+      this addItemToUniform "ACE_EarPlugs";
+
+      this addVest "rhs_6b23_digi_crew";
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rdg2_white";};
+      for "_i" from 1 to 3 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+      for "_i" from 1 to 2 do {this addItemToVest "rhs_mag_rgn";};
+
+      this addHeadgear "rhs_tsh4_ess_bala";
+
+      this addWeapon "rhs_weap_aks74u";
+      this addPrimaryWeaponItem "rhs_acc_dtk";
+
+      this linkItem "ItemMap";
+      this linkItem "ItemCompass";
+      this linkItem "ItemWatch";
+    };
+
+// LOADOUT: DEFAULT/UNDEFINED (use RIFLEMAN)
+    default {
+        if (_typeOfUnit != "r") then {["r", this] call f_fnc_assignGear;};
+        if (true) exitWith {player globalChat format ["DEBUG (f\assignGear\f_assignGear_blufor.sqf): Unit = %1. Gear template %2 does not exist, used Rifleman instead.", this, _typeOfUnit]};
+    };
+};
+
+this selectWeapon primaryWeapon this;


### PR DESCRIPTION
## 1st addition
Country: Israel
Force: Israeli Defense Force
Type: line infantry
Era: '70
Description: Based on [Yom Kippur war equipment](https://en.wikipedia.org/wiki/Yom_Kippur_War#Weapons). Israelis didn't use any LMGs at that point (nor could I find any fitting), so AR is outfitted with the same FAL as everyone else, but carries the 50 round X-FAL magazines for sustained firepower. No bipods were available either. Command units don't have access to an underbarrel GL, because there are no mounts for it on FAL. Unfortunately, none of the listed AT weapons were available (or suitable) for MAT role, so instead I fitted them with RPG-7, saying it was captured from the Arab armies, hence keeping it lore-friendly.

## 2nd addition
Country: Soviet Union
Force: Soviet Army
Type: line infantry (desert)
Era: late '70 - early '90
Description: Soviet line infantry with body armor modeled after [equipment](https://c3.q-assets.com/images/products/p/zkq/zkq-4191_1z.jpg) used in Soviet-Afghanistan war in the '80. Since RHS us missing the RPK series LMGs, the autoriflemen use PKMs, which makes MMG armed with PKP, firing literally the same ammo, virtually useless. Might spice it up in future versions and give MMG some AP belts as well, but I can't make heads or tails from those stupid GRAU designations atm.

## 3rd addition
Country: Russian Federation
Force: Ground Forces of the Russian Federation
Type: line infantry/mountain infantry
Era: modern
Description: AK-74M wielding line infantry, nothing much about it. Only specialty is that they wear green Gorka suits, which makes them suited for cold environments. Especially fitting depiction of [pro-Russian separatists](http://www.probuiltmodel.com/img/galleries2images/ax4kibYf.jpg) figting in current war in Ukraine. 